### PR TITLE
fix oom and more gpu info when oom

### DIFF
--- a/src/cuBERT/Bert.cpp
+++ b/src/cuBERT/Bert.cpp
@@ -41,16 +41,19 @@ namespace cuBERT {
         }
 
         if (var.count("output_weights")) {
+            T* output_weights = var.at("output_weights");
             T* output_bias = var.count("output_bias") ? var.at("output_bias") : nullptr;
-            this->additional_output_layer = new ClassifierOutputLayer<T>(cublas, hidden_size, num_labels, var.at("output_weights"), output_bias, max_batch_size);
+            this->additional_output_layer = new ClassifierOutputLayer<T>(cublas, hidden_size, num_labels, output_weights, output_bias, max_batch_size);
+            this->_logits = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * num_labels));
+            this->_probs = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * num_labels));
         } else {
             this->additional_output_layer = nullptr;
+            this->_logits = nullptr;
+            this->_probs = nullptr;
         }
 
         this->_embedding_output = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * seq_length * hidden_size));
         this->_pooled_output = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * hidden_size));
-        this->_logits = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * num_labels));
-        this->_probs = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * num_labels));
 
         this->input_ids_buf = static_cast<int *>(cuBERT::malloc(sizeof(int) * max_batch_size * seq_length));
         this->input_mask_buf = static_cast<int8_t *>(cuBERT::malloc(sizeof(int8_t) * max_batch_size * seq_length));

--- a/src/cuBERT/BertM.cpp
+++ b/src/cuBERT/BertM.cpp
@@ -30,6 +30,7 @@ namespace cuBERT {
         for (int device = 0; device < count; ++device) {
             auto start = std::chrono::high_resolution_clock::now();
             cuBERT::set_gpu(device);
+            cuBERT::gpu_info(device);
 
             auto *bert = new Bert<T>(graph.var, max_batch_size, seq_length,
                                      graph.vocab_size,

--- a/src/cuBERT/common.h
+++ b/src/cuBERT/common.h
@@ -19,6 +19,7 @@ namespace cuBERT {
 
     int get_gpu_count();
     void set_gpu(int device);
+    void gpu_info(int device);
 
     void *cuda_stream_create();
     void cuda_stream_destroy(void *stream);

--- a/src/cuBERT/tensorflow/Graph.cpp
+++ b/src/cuBERT/tensorflow/Graph.cpp
@@ -83,6 +83,11 @@ namespace cuBERT {
         if (var.empty()) {
             throw std::invalid_argument("model file invalid");
         }
+        std::cerr << "model param: {vocab_size=" << vocab_size
+                  << ";type_vocab_size=" << type_vocab_size
+                  << ";hidden_size=" << hidden_size
+                  << ";intermediate_size=" << intermediate_size
+                  << ";num_labels=}" << num_labels << std::endl;
     }
 
     template <typename T>

--- a/src/cuBERT/tensorflow/Graph.h
+++ b/src/cuBERT/tensorflow/Graph.h
@@ -19,7 +19,7 @@ namespace cuBERT {
         size_t type_vocab_size;
         size_t hidden_size;
         size_t intermediate_size;
-        size_t num_labels;
+        size_t num_labels = 1;
     };
 }
 


### PR DESCRIPTION
The `num_labels` is un-initialized if the model does not have the additional output layer. In this case, 
```
this->_logits = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * num_labels));
this->_probs = static_cast<T *>(cuBERT::malloc(sizeof(T) * max_batch_size * num_labels));
```
will cause out of memory.

In this fix, `_logits` and `_probs` are set nullptr if `num_labels` is unknown. We also add more debug logs at model loading.