### PR TITLE
add python devel docker file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.6)
 project(cuBERT VERSION 0.0.4 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/devel-py.Dockerfile
+++ b/devel-py.Dockerfile
@@ -1,0 +1,21 @@
+FROM quay.io/pypa/manylinux2010_x86_64
+
+WORKDIR /usr/src/cuBERT
+COPY . .
+
+RUN yum -y install \
+        cmake3 \
+        && \
+    yum -y clean all && \
+    rm -rf /var/cache/yum/*
+
+RUN rm -rf build && mkdir build && cd build && \
+    cmake3 -DCMAKE_BUILD_TYPE=Release -DcuBERT_ENABLE_MKL_SUPPORT=ON .. && \
+    make
+
+RUN /opt/python/cp36-cp36m/bin/pip install Cython numpy
+RUN /opt/python/cp27-cp27m/bin/pip install Cython numpy
+
+RUN cd python && \
+    /opt/python/cp36-cp36m/bin/python setup.py bdist_wheel && \
+    /opt/python/cp27-cp27m/bin/python setup.py bdist_wheel

--- a/test/cuBERT/BertMTest.cpp
+++ b/test/cuBERT/BertMTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "common_test.h"
 #include "cuBERT/BertM.h"
 using namespace cuBERT;

--- a/test/cuBERT/BertTest.cpp
+++ b/test/cuBERT/BertTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <unordered_map>
 
 #include "common_test.h"

--- a/test/cuBERT/common_test.cpp
+++ b/test/cuBERT/common_test.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "common_test.h"
 
 TEST_F(CommonTest, memcpy) {

--- a/test/cuBERT/common_test.h
+++ b/test/cuBERT/common_test.h
@@ -1,11 +1,12 @@
 #ifndef CUBERT_COMMON_TEST_H
 #define CUBERT_COMMON_TEST_H
 
-#include "gtest/gtest.h"
 #include <cstdlib>
 #include <cstring>
 
 #include "cuBERT/common.h"
+
+#include "gtest/gtest.h"
 
 class CommonTest : public ::testing::Test {
 protected:

--- a/test/cuBERT/op/DenseTest.cpp
+++ b/test/cuBERT/op/DenseTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "../common_test.h"
 #include "cuBERT/op/Dense.h"
 using namespace cuBERT;

--- a/test/cuBERT/op/EmbeddingTest.cpp
+++ b/test/cuBERT/op/EmbeddingTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "../common_test.h"
 #include "cuBERT/op/Embedding.h"
 using namespace cuBERT;

--- a/test/cuBERT/op/GELUTest.cpp
+++ b/test/cuBERT/op/GELUTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <cmath>
 
 #include "../common_test.h"

--- a/test/cuBERT/op/LayerNormTest.cpp
+++ b/test/cuBERT/op/LayerNormTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <cmath>
 
 #include "../common_test.h"

--- a/test/cuBERT/op/SoftmaxTest.cpp
+++ b/test/cuBERT/op/SoftmaxTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "../common_test.h"
 #include "cuBERT/op/Softmax.h"
 using namespace cuBERT;

--- a/test/cuBERT/op_att/AttentionMaskTest.cpp
+++ b/test/cuBERT/op_att/AttentionMaskTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "../common_test.h"
 #include "cuBERT/op_att/AttentionMask.h"
 using namespace cuBERT;

--- a/test/cuBERT/op_att/AttentionSelfTest.cpp
+++ b/test/cuBERT/op_att/AttentionSelfTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <algorithm>
 
 #include "../common_test.h"

--- a/test/cuBERT/op_att/BatchMatMulTest.cpp
+++ b/test/cuBERT/op_att/BatchMatMulTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "../common_test.h"
 #include "cuBERT/op_att/BatchMatMul.h"
 using namespace cuBERT;

--- a/test/cuBERT/op_att/TransformerTest.cpp
+++ b/test/cuBERT/op_att/TransformerTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <algorithm>
 
 #include "../common_test.h"

--- a/test/cuBERT/op_bert/BertEmbeddingsTest.cpp
+++ b/test/cuBERT/op_bert/BertEmbeddingsTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <cmath>
 
 #include "../common_test.h"

--- a/test/cuBERT/op_bert/BertPoolerTest.cpp
+++ b/test/cuBERT/op_bert/BertPoolerTest.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <cmath>
 
 #include "../common_test.h"

--- a/test/cuBERT/op_out/AdditionalOutputLayerTest.cpp
+++ b/test/cuBERT/op_out/AdditionalOutputLayerTest.cpp
@@ -1,5 +1,3 @@
-#include "gtest/gtest.h"
-
 #include "../common_test.h"
 #include "cuBERT/op_out/AdditionalOutputLayer.h"
 using namespace cuBERT;


### PR DESCRIPTION
half.hpp v2.1 will conflict with gtest.h (signal.h) on function `raise(FE_INEXACT);` (`int raise(int sig)`). So we play a trick to move include order of gtest.h under `cuBERT/common.h`.